### PR TITLE
Add a fallback checks for PHP & WooCommerce versions

### DIFF
--- a/load.php
+++ b/load.php
@@ -18,6 +18,11 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
+// PHP 5.6+ required
+if ( PHP_VERSION_ID < 50600 ) {
+	return;
+}
+
 // only proceed if some other plugin hasn't already loaded this version
 if ( ! function_exists( 'sv_wc_jilt_promotions_initialize_1_0_1' ) ) {
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -47,6 +47,11 @@ class Package {
 	 */
 	public function __construct() {
 
+		// bail if WooCommerce is not active or compatible
+		if ( ! self::is_woocommerce_compatible() ) {
+			return;
+		}
+
 		$this->includes();
 
 		// load the translation files

--- a/src/Package.php
+++ b/src/Package.php
@@ -110,6 +110,29 @@ class Package {
 	}
 
 
+	/** Conditional methods *******************************************************************************************/
+
+
+	/**
+	 * Determines if WooCommerce is active.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_active() {
+
+		if ( ! did_action( 'plugins_loaded' ) ) {
+			_doing_it_wrong( __METHOD__, 'Cannot be called before plugins_loaded is fired', 'x.y.z' );
+		}
+
+		return function_exists( 'WC' );
+	}
+
+
+	/** Utility methods ***********************************************************************************************/
+
+
 	/**
 	 * Gets the one true instance of Package.
 	 *

--- a/src/Package.php
+++ b/src/Package.php
@@ -32,6 +32,9 @@ class Package {
 	/** @var string the package version */
 	const VERSION = '1.0.1';
 
+	/** @var string the minimum required version of WooCommerce */
+	const MINIMUM_WOOCOMMERCE_VERSION = '3.0';
+
 
 	/** @var Package single instance of this package */
 	private static $instance;
@@ -127,6 +130,19 @@ class Package {
 		}
 
 		return function_exists( 'WC' );
+	}
+
+
+	/**
+	 * Determines if the current version WooCommerce is compatible with this package.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	private static function is_woocommerce_compatible() {
+
+		return self::is_woocommerce_active() && defined( 'WC_VERSION' ) && version_compare( WC_VERSION, self::MINIMUM_WOOCOMMERCE_VERSION, '>=' );
 	}
 
 


### PR DESCRIPTION
Awwww, the very first PR.

# Summary

While most plugins will be checking these versions in advance of loading this package, we should still have a fallback just in case.

### Story: [CH 56679](https://app.clubhouse.io/skyverge/story/56679)

## UI Changes

None

## QA

1. Activate any [WC plugin](https://github.com/skyverge/wc-plugins)
1. Remove the `is_woocommerce_active()` check at the top of the main plugin file
1. Deactivate WooCommerce
    - [x] Fatal!
1. Update the plugin's composer to load `dev-ch56679/add-fallback-checks-for-php-woocommerce-versions`
1. Load the admin again
    - [x] No fatal!
1. Activate WooCommerce
1. Go to WooCommerce -> Settings -> Emails
    - [x] The "Install Jilt" button is present at the bottom of email settings (be sure the `_sv_wc_jilt_hide_emails_prompt` meta isn't set for your user)

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version