### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.2 - 2020.07.09
+* Check that the site meets the minimum PHP and WooCommerce versions requirements before loading the package
+
 ## v1.0.1 - 2020.05.04
 * Don't query the "hide" user meta outside the admin
 * Only display the install prompt for shop admins

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
   "name": "skyverge/wc-jilt-promotions",
   "description": "Callouts to promote Jilt in WooCommerce",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('makepot', function () {
 });
 
 gulp.task('minify', function() {
-	return gulp.src('src/assets/js/**/*.js')
+	return gulp.src(['src/assets/js/**/*.js', '!src/assets/js/**/*.min.js'])
 		.pipe(minify( {
 			ext: {
 				min: '.min.js'

--- a/load.php
+++ b/load.php
@@ -24,7 +24,7 @@ if ( PHP_VERSION_ID < 50600 ) {
 }
 
 // only proceed if some other plugin hasn't already loaded this version
-if ( ! function_exists( 'sv_wc_jilt_promotions_initialize_1_0_1' ) ) {
+if ( ! function_exists( 'sv_wc_jilt_promotions_initialize_1_0_2' ) ) {
 
 	// load the versions handler unless already loaded
 	if ( ! class_exists( '\SkyVerge\WooCommerce\Jilt_Promotions\Versions' ) ) {
@@ -34,17 +34,17 @@ if ( ! function_exists( 'sv_wc_jilt_promotions_initialize_1_0_1' ) ) {
 		add_action( 'plugins_loaded', [ \SkyVerge\WooCommerce\Jilt_Promotions\Versions::class, 'initialize_latest_version' ], 99, 0 );
 	}
 
-	// register v1.0.1
-	\SkyVerge\WooCommerce\Jilt_Promotions\Versions::register( '1.0.1', 'sv_wc_jilt_promotions_initialize_1_0_1' );
+	// register v1.0.2
+	\SkyVerge\WooCommerce\Jilt_Promotions\Versions::register( '1.0.2', 'sv_wc_jilt_promotions_initialize_1_0_2' );
 
 	/**
-	 * Initializes the Jilt Promotions package v1.0.1.
+	 * Initializes the Jilt Promotions package v1.0.2.
 	 *
 	 * This function should not be called directly.
 	 *
-	 * @since 1.0.1
+	 * @since 1.0.2
 	 */
-	function sv_wc_jilt_promotions_initialize_1_0_1() {
+	function sv_wc_jilt_promotions_initialize_1_0_2() {
 
 		require_once( 'src/Package.php' );
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -30,7 +30,7 @@ class Package {
 	const ID = 'sv-wc-jilt-promotions';
 
 	/** @var string the package version */
-	const VERSION = '1.0.1';
+	const VERSION = '1.0.2';
 
 	/** @var string the minimum required version of WooCommerce */
 	const MINIMUM_WOOCOMMERCE_VERSION = '3.0';

--- a/src/i18n/languages/sv-wc-jilt-promotions.pot
+++ b/src/i18n/languages/sv-wc-jilt-promotions.pot
@@ -18,75 +18,75 @@ msgstr ""
 msgid "Whoops, looks like there was an error installing Jilt for WooCommerce - please install manually %1$sfrom the Plugins menu%2$s."
 msgstr ""
 
-#: src/Admin/Emails.php:199
+#: src/Admin/Emails.php:204
 msgid "Jilt for WooCommerce"
 msgstr ""
 
-#: src/Admin/Emails.php:209
+#: src/Admin/Emails.php:214
 msgid "Jilt for WooCommerce successfully installed"
 msgstr ""
 
 #. translators: Placeholders: %s - install error message
-#: src/Admin/Emails.php:218
+#: src/Admin/Emails.php:223
 msgid "Could not install Jilt for WooCommerce. %s"
 msgstr ""
 
 #. translators: Placeholders; %1$s - <a> tag, %2$s - </a> tag, %3$s - <a> tag, %4$s - </a> tag, %5$s - <a> tag, %6$s - </a> tag
-#: src/Admin/Emails.php:253
+#: src/Admin/Emails.php:258
 msgid "Create beautiful automated, transactional, and marketing emails using a drag-and-drop editor with %1$sJilt%2$s. Learn more about free and paid plans in the %3$sdocumentation%4$s. Brought to you by %5$sSkyVerge%6$s."
 msgstr ""
 
-#: src/Admin/Emails.php:270
+#: src/Admin/Emails.php:275
 msgid "Advanced emails"
 msgstr ""
 
-#: src/Admin/Emails.php:310
+#: src/Admin/Emails.php:315
 msgid "Customize this email"
 msgstr ""
 
-#: src/Admin/Emails.php:329
+#: src/Admin/Emails.php:334
 msgid "Enhanced emails with Jilt"
 msgstr ""
 
-#: src/Admin/Emails.php:349
+#: src/Admin/Emails.php:354
 msgid "This setting is shown because you currently have a SkyVerge plugin active."
 msgstr ""
 
-#: src/Admin/Emails.php:359, src/views/admin/html-install-plugin-modal.php:24
+#: src/Admin/Emails.php:364, src/views/admin/html-install-plugin-modal.php:24
 msgid "Install Jilt"
 msgstr ""
 
-#: src/Admin/Emails.php:360
+#: src/Admin/Emails.php:365
 msgid "Hide this setting"
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:486
+#: src/Admin/Emails.php:485
 msgid "Personalize your receipts using a drag-and-drop editor with %1$sJilt%2$s. Send different versions of your receipt based on customer or order details (change it for international orders!), cross-sell other products, include a dynamic coupon for the next order, and more."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:496
+#: src/Admin/Emails.php:495
 msgid "Personalize your shipment notifications using a drag-and-drop editor with %1$sJilt%2$s. Send beautiful transactional emails, change customer messaging, cross-sell other products, include a dynamic coupon for the next order, and more."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:506
+#: src/Admin/Emails.php:505
 msgid "Save the sale! Create beautiful, personalized transactional emails using a drag-and-drop editor with %1$sJilt%2$s. Show refund details, sell related products, or include a discount for the next order."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:521
+#: src/Admin/Emails.php:520
 msgid "Keep your subscribers in the loop: create personalized, automated emails using a drag-and-drop editor with %1$sJilt%2$s. Send welcome or winback series, pre-renewal notifications, subscriber newsletters, and more."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:534
+#: src/Admin/Emails.php:533
 msgid "Brought to you by %1$sSkyVerge%2$s."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: src/Admin/Emails.php:561
+#: src/Admin/Emails.php:560
 msgid "Create beautiful automated and transactional emails using a drag-and-drop editor with %1$sJilt%2$s. Personalize email content with customer and order details — include cross-sells, remind customers to complete payment, or easily share vital order information."
 msgstr ""
 


### PR DESCRIPTION
# Summary

We have at least [one report](https://github.com/skyverge/woocommerce-shipping-estimate/issues/25) of a Fatal error triggered when WooCommerce is deactivated. I think we should tag a new version of the package and start including it as we release updates for our plugins to gradually reduce the risk of causing similar errors.

I don't think the Fatal error reported above is a widespread problem. The user mentioned that the Fatal error occurred while trying to update WooCommerce from the `wp-admin/update-core.php` page. However, I wasn't able to reproduce a Fatal error using that page, the update link, or updating with WP-CLI.

## QA

- [x] Version number updates look good
- [x] Update a plugin to use branch `dev-release/1.0.2` of the `wc-jilt-promotions` package and confirm the package loads normally