### PR TITLE
Create the Prompt abstract handler

### DIFF
--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -25,4 +25,19 @@ defined( 'ABSPATH' ) or exit;
  * @since 1.1.0-dev.1
  */
 abstract class Prompt {
+
+
+	/** @var string the source value for the connection arguments */
+	const UTM_SOURCE = 'jilt-for-woocommerce';
+
+	/** @var string the medium value for the connection arguments */
+	const UTM_MEDIUM = 'oauth';
+
+	/** @var string the campaign value for the connection arguments */
+	const UTM_CAMPAIGN = 'wc-plugin-promo';
+
+	/** @var string the content value for the connection arguments */
+	const UTM_CONTENT = 'install-jilt-button';
+
+
 }

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -40,4 +40,19 @@ abstract class Prompt {
 	const UTM_CONTENT = 'install-jilt-button';
 
 
+
+
+	/**
+	 * Whether Jilt is already installed.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	protected function is_jilt_plugin_installed() {
+
+		return function_exists( 'wc_jilt' );
+	}
+
+
 }

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -43,6 +43,17 @@ abstract class Prompt {
 
 
 	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
+	/**
 	 * Adds the necessary action & filter hooks.
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Jilt for WooCommerce Promotions
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2020, SkyVerge, Inc. (info@skyverge.com)
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\Jilt_Promotions\Handlers;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The base prompts handler.
+ *
+ * @since 1.1.0-dev.1
+ */
+abstract class Prompt {
+}

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -40,6 +40,26 @@ abstract class Prompt {
 	const UTM_CONTENT = 'install-jilt-button';
 
 
+	/**
+	 * Whether the Jilt install prompt should be displayed.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return bool
+	 */
+	protected function should_display_prompt() {
+
+		$display = current_user_can( 'install_plugins' ) && ! $this->is_jilt_plugin_installed();
+
+		/**
+		 * Filters whether the Jilt install prompt should be displayed.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool $should_display whether the Jilt install prompt should be displayed
+		 */
+		return (bool) apply_filters( 'sv_wc_jilt_prompt_should_display', $display );
+	}
 
 
 	/**

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -17,6 +17,8 @@
 
 namespace SkyVerge\WooCommerce\Jilt_Promotions\Handlers;
 
+use SkyVerge\WooCommerce\Jilt_Promotions\Admin\Emails;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -50,6 +52,8 @@ abstract class Prompt {
 	protected function should_display_prompt() {
 
 		$display = current_user_can( 'install_plugins' ) && ! $this->is_jilt_plugin_installed();
+
+		$display = $display && ! wc_string_to_bool( get_user_meta( get_current_user_id(), Emails::META_KEY_HIDE_PROMPT, true ) );
 
 		/**
 		 * Filters whether the Jilt install prompt should be displayed.

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -43,6 +43,29 @@ abstract class Prompt {
 
 
 	/**
+	 * Adds the necessary action & filter hooks.
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	private function add_hooks() {
+
+		if ( is_admin() && $this->should_display_prompt() ) {
+			$this->add_prompt_hooks();
+		}
+	}
+
+
+	/**
+	 * Adds the necessary action & filter hooks.
+	 *
+	 * Subclasses can use this method to setup hooks only when the prompt should be displayed.
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	abstract protected function add_prompt_hooks();
+
+
+	/**
 	 * Whether the Jilt install prompt should be displayed.
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -133,6 +133,8 @@ abstract class Prompt {
 
 		$display = $display && ! wc_string_to_bool( get_user_meta( get_current_user_id(), Emails::META_KEY_HIDE_PROMPT, true ) );
 
+		// TODO: check that Messages::get_dismissed_messages() returns an empty array {WV 2020-08-11}
+
 		/**
 		 * Filters whether the Jilt install prompt should be displayed.
 		 *

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -63,6 +63,9 @@ abstract class Prompt {
 		if ( is_admin() && $this->should_display_prompt() ) {
 			$this->add_prompt_hooks();
 		}
+
+		// add the connection redirect args if the plugin was installed from this prompt
+		add_filter( 'wc_jilt_app_connection_redirect_args', [ $this, 'add_connection_redirect_args' ] );
 	}
 
 

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -77,6 +77,47 @@ abstract class Prompt {
 
 
 	/**
+	 * Adds the connection redirect args if the plugin was installed from this prompt.
+	 *
+	 * @internal
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @param array $args redirect args
+	 * @return array
+	 */
+	public function add_connection_redirect_args( $args ) {
+
+		if ( $new_args = $this->get_connection_redirect_args() && ! empty( $new_args['utm_term'] ) ) {
+
+			$utm_campaign = isset( $new_args['utm_campaign'] ) ? $new_args['utm_campaign'] : self::UTM_CAMPAIGN;
+
+			$args['utm_source']   = isset( $new_args['utm_source'] )   ? $new_args['utm_source']   : self::UTM_SOURCE;
+			$args['utm_medium']   = isset( $new_args['utm_medium'] )   ? $new_args['utm_medium']   : self::UTM_MEDIUM;
+			$args['utm_campaign'] = $utm_campaign;
+			$args['utm_content']  = isset( $new_args['utm_content' ] ) ? $new_args['utm_content']  : self::UTM_CONTENT;
+			$args['utm_term']     = str_replace( '_', '-', wc_clean( $new_args['utm_term'] ) );
+			$args['partner']      = '1';
+			$args['campaign']     = $utm_campaign;
+		}
+
+		return $args;
+	}
+
+
+	/**
+	 * Gets the connection redirect args to attribute the plugin installation to this prompt.
+	 *
+	 * The returned array will be used only if it includes the utm_term arg.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	abstract protected function get_connection_redirect_args();
+
+
+	/**
 	 * Whether the Jilt install prompt should be displayed.
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Package.php
+++ b/src/Package.php
@@ -66,6 +66,7 @@ class Package {
 	 */
 	private function includes() {
 
+		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
 
 		new Admin\Emails();


### PR DESCRIPTION
# Summary

This PR adds the base handler for Jilt prompts.

### Story: [CH 60951](https://app.clubhouse.io/skyverge/story/60951/create-the-prompt-abstract-handler)
### Release: #3 

## Details

Fulvio mentioned that `is_jilt_plugin_installed()` was a better name for the method to check whether Jilt for WooCommerce is already installed. I noticed that the existing `is_plugin_installed()` method in `Emails` is a private one, so I think there is no harm in using the new name here and removing the older one when we update that class.

## QA

- [x] Code review

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version