### PR TITLE
Create the Messages handler

### DIFF
--- a/src/Messages.php
+++ b/src/Messages.php
@@ -73,4 +73,16 @@ class Messages {
 	}
 
 
+	/**
+	 * Marks a message as dismissed.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $message_id message identifier
+	 */
+	public static function dismiss_message( $message_id ) {
+
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -26,4 +26,18 @@ defined( 'ABSPATH' ) or exit;
  */
 class Messages {
 
+
+	/** @var string user meta key name for storing enabled messages */
+	const META_KEY_ENABLED_MESSAGES = '_sv_wc_jilt_enabled_messages';
+
+	/** @var string user meta key name for storing disabled messages */
+	const META_KEY_DISMISSED_MESSAGES = '_sv_wc_jilt_dismissed_messages';
+
+	/** @var string AJAX action hook name for enabling messages */
+	const AJAX_ACTION_ENABLE_MESSAGE = 'sv_wc_jilt_enable_message';
+
+	/** @var string AJAX action hook name for disabling messages */
+	const AJAX_ACTION_DISABLE_MESSAGE = 'sv_wc_jilt_disable_message';
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -61,4 +61,16 @@ class Messages {
 	}
 
 
+	/**
+	 * Marks a message as enabled.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $message_id message identifier
+	 */
+	public static function enable_message( $message_id ) {
+
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -124,5 +124,18 @@ class Messages {
 		return false;
 	}
 
+	/**
+	 * Determines whether a message has been dismissed.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $message_id message identifier
+	 * @return bool
+	 */
+	public static function is_message_dismissed( $message_id ) {
+
+		return false;
+	}
+
 
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -51,4 +51,14 @@ class Messages {
 	}
 
 
+	/**
+	 * Adds hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	private function add_hooks() {
+
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -85,4 +85,17 @@ class Messages {
 	}
 
 
+	/**
+	 * Gets the enabled messages for the current user.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array
+	 */
+	public static function get_enabled_messages() {
+
+		return [];
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -20,7 +20,7 @@ namespace SkyVerge\WooCommerce\Jilt_Promotions;
 defined( 'ABSPATH' ) or exit;
 
 /**
- * The base package class.
+ * The messages handler class.
  *
  * @since 1.1.0
  */

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -138,4 +138,28 @@ class Messages {
 	}
 
 
+	/**
+	 * Enables a message via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 1.1.0
+	 */
+	public function ajax_enable_message() {
+
+	}
+
+
+	/**
+	 * Dismisses a message via AJAX.
+	 *
+	 * @internal
+	 *
+	 * @since 1.1.0
+	 */
+	public function ajax_dismiss_message() {
+
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -40,4 +40,15 @@ class Messages {
 	const AJAX_ACTION_DISABLE_MESSAGE = 'sv_wc_jilt_disable_message';
 
 
+	/**
+	 * Messages constructor.
+	 *
+	 * @since 1.1.0
+	 */
+	public function __construct() {
+
+		$this->add_hooks();
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -30,14 +30,14 @@ class Messages {
 	/** @var string user meta key name for storing enabled messages */
 	const META_KEY_ENABLED_MESSAGES = '_sv_wc_jilt_enabled_messages';
 
-	/** @var string user meta key name for storing disabled messages */
+	/** @var string user meta key name for storing dismissed messages */
 	const META_KEY_DISMISSED_MESSAGES = '_sv_wc_jilt_dismissed_messages';
 
 	/** @var string AJAX action hook name for enabling messages */
 	const AJAX_ACTION_ENABLE_MESSAGE = 'sv_wc_jilt_enable_message';
 
-	/** @var string AJAX action hook name for disabling messages */
-	const AJAX_ACTION_DISABLE_MESSAGE = 'sv_wc_jilt_disable_message';
+	/** @var string AJAX action hook name for dismissing messages */
+	const AJAX_ACTION_DISMISS_MESSAGE = 'sv_wc_jilt_dismiss_message';
 
 
 	/**

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -111,4 +111,18 @@ class Messages {
 	}
 
 
+	/**
+	 * Determines whether a message is enabled.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $message_id message identifier
+	 * @return bool
+	 */
+	public static function is_message_enabled( $message_id ) {
+
+		return false;
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -98,4 +98,17 @@ class Messages {
 	}
 
 
+	/**
+	 * Gets the dismissed messages for the current user.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array
+	 */
+	public static function get_dismissed_messages() {
+
+		return [];
+	}
+
+
 }

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Jilt for WooCommerce Promotions
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2020, SkyVerge, Inc. (info@skyverge.com)
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\Jilt_Promotions;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The base package class.
+ *
+ * @since 1.1.0
+ */
+class Messages {
+
+}

--- a/src/Messages.php
+++ b/src/Messages.php
@@ -62,7 +62,7 @@ class Messages {
 
 
 	/**
-	 * Marks a message as enabled.
+	 * Marks a message as enabled for the current user.
 	 *
 	 * @since 1.1.0
 	 *
@@ -74,7 +74,7 @@ class Messages {
 
 
 	/**
-	 * Marks a message as dismissed.
+	 * Marks a message as dismissed for the current user.
 	 *
 	 * @since 1.1.0
 	 *
@@ -112,7 +112,7 @@ class Messages {
 
 
 	/**
-	 * Determines whether a message is enabled.
+	 * Determines whether a message is enabled for the current user.
 	 *
 	 * @since 1.1.0
 	 *
@@ -125,7 +125,7 @@ class Messages {
 	}
 
 	/**
-	 * Determines whether a message has been dismissed.
+	 * Determines whether a message has been dismissed for the current user.
 	 *
 	 * @since 1.1.0
 	 *

--- a/src/Package.php
+++ b/src/Package.php
@@ -26,6 +26,7 @@ defined( 'ABSPATH' ) or exit;
  */
 class Package {
 
+
 	/** @var string the package ID */
 	const ID = 'sv-wc-jilt-promotions';
 
@@ -66,9 +67,11 @@ class Package {
 	 */
 	private function includes() {
 
+		require_once( self::get_package_path() . '/Messages.php' );
 		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
 
+		new Messages();
 		new Admin\Emails();
 	}
 


### PR DESCRIPTION
# Summary

This PR adds the `Messages` handler.

### Story: [CH 60939](https://app.clubhouse.io/skyverge/story/60939/create-the-messages-handler)
### Release: #3 

## Details

It instantiates in the `Package::includes()` so later the AJAX callbacks will be triggered from the `add_hooks()` method fired from constructor.

## QA

- [x] Code review

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version