### PR TITLE
Create the Notice object

### DIFF
--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -60,4 +60,18 @@ class Notice {
 	}
 
 
+
+	/**
+	 * Gets the notice message ID.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	public function get_message_id() {
+
+		return $this->message_id;
+	}
+
+
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -34,7 +34,7 @@ class Notice {
 	const ACTION_TYPE_LINK = 'link';
 
 
-	/** @var string the notice identifier */
+	/** @var string the notice message identifier */
 	private $message_id = '';
 
 	/** @var string the notice title */
@@ -45,6 +45,19 @@ class Notice {
 
 	/** @var array the notice actions */
 	private $actions = [];
+
+
+	/**
+	 * Sets the notice message ID.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $message_id message identifier
+	 */
+	public function set_message_id( $message_id ) {
+
+		$this->message_id = $message_id;
+	}
 
 
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -20,7 +20,7 @@ namespace SkyVerge\WooCommerce\Jilt_Promotions;
 defined( 'ABSPATH' ) or exit;
 
 /**
- * The base package class.
+ * The notice object.
  *
  * @since 1.0.0
  */

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -111,5 +111,17 @@ class Notice {
 		$this->content = $content;
 	}
 
+	/**
+	 * Gets the notice content.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	public function get_content() {
+
+		return $this->content;
+	}
+
 
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -26,4 +26,12 @@ defined( 'ABSPATH' ) or exit;
  */
 class Notice {
 
+
+	/** @var string "button" notice action type */
+	const ACTION_TYPE_BUTTON = 'button';
+
+	/** @var string "link" notice action type */
+	const ACTION_TYPE_LINK = 'link';
+
+
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -171,4 +171,34 @@ class Notice {
 	}
 
 
+	/**
+	 * Outputs the notice.
+	 *
+	 * @since 1.1.0
+	 */
+	public function render() {
+
+	}
+
+
+	/**
+	 * Outputs the notice content.
+	 *
+	 * @since 1.1.0
+	 */
+	private function render_content() {
+
+	}
+
+
+	/**
+	 * Outputs the notice actions.
+	 *
+	 * @since 1.1.0
+	 */
+	private function render_actions() {
+
+	}
+
+
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -111,6 +111,7 @@ class Notice {
 		$this->content = $content;
 	}
 
+
 	/**
 	 * Gets the notice content.
 	 *
@@ -121,6 +122,52 @@ class Notice {
 	public function get_content() {
 
 		return $this->content;
+	}
+
+
+	/**
+	 * Parses a set of actions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array $actions actions to parse
+	 * @return array
+	 */
+	private function parse_actions( array $actions ) {
+
+		return wp_parse_args( $actions, [
+			'label'   => '',
+			'name'    => '',
+			'url'     => '',
+			'primary' => false,
+			'type'    => self::ACTION_TYPE_LINK,
+		] );
+	}
+
+
+	/**
+	 * Sets the notice actions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array $actions the notice actions
+	 */
+	public function set_actions( array $actions ) {
+
+		$this->actions = $this->parse_actions( $actions );
+	}
+
+
+	/**
+	 * Gets the notice actions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array
+	 */
+	public function get_actions() {
+
+		return $this->parse_actions( $this->actions );
 	}
 
 

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -60,7 +60,6 @@ class Notice {
 	}
 
 
-
 	/**
 	 * Gets the notice message ID.
 	 *
@@ -71,6 +70,19 @@ class Notice {
 	public function get_message_id() {
 
 		return $this->message_id;
+	}
+
+
+	/**
+	 * Sets the notice title.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $title the notice title
+	 */
+	public function set_title( $title ) {
+
+		$this->title = $title;
 	}
 
 

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Jilt for WooCommerce Promotions
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2020, SkyVerge, Inc. (info@skyverge.com)
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\Jilt_Promotions;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * The base package class.
+ *
+ * @since 1.0.0
+ */
+class Notice {
+
+}

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -15,14 +15,14 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  */
 
-namespace SkyVerge\WooCommerce\Jilt_Promotions;
+namespace SkyVerge\WooCommerce\Jilt_Promotions\Notices;
 
 defined( 'ABSPATH' ) or exit;
 
 /**
  * The notice object.
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
 class Notice {
 

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -99,4 +99,17 @@ class Notice {
 	}
 
 
+	/**
+	 * Sets the notice content.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $content the notice content
+	 */
+	public function set_content( $content ) {
+
+		$this->content = $content;
+	}
+
+
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -34,4 +34,17 @@ class Notice {
 	const ACTION_TYPE_LINK = 'link';
 
 
+	/** @var string the notice identifier */
+	private $message_id = '';
+
+	/** @var string the notice title */
+	private $title = '';
+
+	/** @var string the notice content */
+	private $content = '';
+
+	/** @var array the notice actions */
+	private $actions = [];
+
+
 }

--- a/src/Notices/Notice.php
+++ b/src/Notices/Notice.php
@@ -86,4 +86,17 @@ class Notice {
 	}
 
 
+	/**
+	 * Gets the notice title.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+
+		return $this->title;
+	}
+
+
 }

--- a/src/Package.php
+++ b/src/Package.php
@@ -66,7 +66,7 @@ class Package {
 	 */
 	private function includes() {
 
-		require_once ( self::get_package_path() . '/Notices/Notice.php' );
+		require_once( self::get_package_path() . '/Notices/Notice.php' );
 		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -66,6 +66,7 @@ class Package {
 	 */
 	private function includes() {
 
+		require_once ( self::get_package_path() . '/Notices/Notice.php' );
 		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
 


### PR DESCRIPTION
# Summary

This PR adds the `Notice` object.

### Story: [CH 60967](https://app.clubhouse.io/skyverge/story/60967/create-the-notice-object)
### Release: #3 

## Details

I've added a `parse_actions()` helper method to ensure that the actions contain always the expected array keys.

## QA

- [x] Code review

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version