### PR TITLE
Create the Orders class

### DIFF
--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -56,6 +56,19 @@ class Orders extends Prompt {
 
 
 	/**
+	 * Returns the estimated number of abandoned carts for the last 30 days.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @retun float
+	 */
+	private function get_abandoned_carts_count() {
+
+		return 0.0;
+	}
+
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -26,4 +26,9 @@ defined( 'ABSPATH' ) or exit;
  */
 class Orders {
 
+
+	/** @var string the id associated with the message */
+	private $abandoned_carts_filter_message_id = 'orders-abandoned-carts-filter';
+
+
 }

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Jilt for WooCommerce Promotions
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2020, SkyVerge, Inc. (info@skyverge.com)
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Handles the modal shown when merchants select the Abandoned Carts filter view on the Orders page.
+ *
+ * @since 1.1.0-dev.1
+ */
+class Orders {
+
+}

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -66,4 +66,15 @@ class Orders extends Prompt {
 	}
 
 
+	/**
+	 * Retrieves the abandoned carts count and the recovered revenue to render the recover carts modal.
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	public function render_recover_carts_modal() {
+
+
+	}
+
+
 }

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -17,6 +17,8 @@
 
 namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
 
+use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
+
 defined( 'ABSPATH' ) or exit;
 
 /**
@@ -24,11 +26,32 @@ defined( 'ABSPATH' ) or exit;
  *
  * @since 1.1.0-dev.1
  */
-class Orders {
+class Orders extends Prompt {
 
 
 	/** @var string the id associated with the message */
 	private $abandoned_carts_filter_message_id = 'orders-abandoned-carts-filter';
+
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	protected function add_prompt_hooks() {
+
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since 1.1.0-dev.1
+	 */
+	protected function get_connection_redirect_args() {
+
+		return [];
+	}
 
 
 }

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -80,6 +80,61 @@ class Orders extends Prompt {
 
 
 	/**
+	 * Returns the number of orders placed in the last 30 days.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return int
+	 */
+	private function get_orders_count() {
+
+		return 0;
+	}
+
+
+	/**
+	 * Returns the gross sales for the last 30 days.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return float
+	 */
+	private function get_orders_revenue() {
+
+		return 0.0;
+	}
+
+
+	/**
+	 * Returns the estimated recovered revenue from abandoned carts fort the last 30 days.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return float
+	 */
+	private function get_recovered_revenue() {
+
+		return 0.0;
+	}
+
+
+	/**
+	 * Returns the number of orders placed in the last 30 days and the gross sales for that period.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @return array
+	 */
+	private function get_sales_data() {
+
+		return [
+			'number_of_orders' => 0,
+			'gross_sales'      => 0.0,
+		];
+	}
+
+
+	/**
 	 * Retrieves the abandoned carts count and the recovered revenue to render the recover carts modal.
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -34,6 +34,18 @@ class Orders extends Prompt {
 
 
 	/**
+	 * Callback for the views_edit-shop_order filter.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @param array $views
+	 */
+	public function add_abandoned_carts_view( $views ) {
+
+	}
+
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Package.php
+++ b/src/Package.php
@@ -70,6 +70,7 @@ class Package {
 		require_once( self::get_package_path() . '/Messages.php' );
 		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
+		require_once( self::get_package_path() . '/Admin/Orders.php' );
 
 		new Messages();
 		new Admin\Emails();


### PR DESCRIPTION
# Summary

This PR adds the `Orders` class and its method stubs. The implementation will be done in [ch61183](https://app.clubhouse.io/skyverge/story/61183/implement-admin-orders-methods).

### Story: [CH 61072](https://app.clubhouse.io/skyverge/story/61072/create-the-admin-orders-class)
### Release: #3 

## QA

- [x] Code review

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version