### PR TITLE
Create Customers message handler

### DIFF
--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -117,7 +117,7 @@ final class Customers extends Prompt {
 						<article><?php esc_html_e( 'Jilt automatically syncs your store and customer data, so you can send powerful, personalized messages to your customers with just a few clicks.', 'sv-wc-jilt-promotions' ); ?></article>
 						<footer>
 							<div class="inner">
-								<a href=""><?php esc_html_e( 'Learn more', 'sv-wc-jilt-promotions' ); ?></a>
+								<a href="https://www.skyverge.com/go/customer-communication" target="_blank"><?php esc_html_e( 'Learn more', 'sv-wc-jilt-promotions' ); ?></a>
 								<button id="sv-wc-jilt-install-button-install" class="button button-large button-primary"><?php esc_html_e( 'I want to try Jilt', 'sv-wc-jilt-promotions' ); ?></button>
 							</div>
 						</footer>

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -22,6 +22,7 @@ defined( 'ABSPATH' ) or exit;
 use Automattic\WooCommerce\Admin\PageController;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Installation;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
+use SkyVerge\WooCommerce\Jilt_Promotions\Messages;
 use SkyVerge\WooCommerce\Jilt_Promotions\Package;
 
 /**
@@ -37,6 +38,22 @@ final class Customers extends Prompt {
 
 	/** @var string the ID of the Customers page */
 	private $customers_page_id = 'woocommerce-analytics-customers';
+
+
+	/**
+	 * Adds the necessary action & filter hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	protected function add_prompt_hooks() {
+
+		if ( ! Messages::is_message_enabled( $this->download_message_id ) ) {
+
+			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+			add_action( 'admin_footer', [ $this, 'render_try_jilt_modal' ] );
+		}
+	}
 
 
 	/**

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -57,6 +57,27 @@ final class Customers extends Prompt {
 
 
 	/**
+	 * Gets the connection redirect args to attribute the plugin installation to this prompt.
+	 *
+	 * @see Prompt::add_connection_redirect_args()
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array
+	 */
+	protected function get_connection_redirect_args() {
+
+		$args = [];
+
+		if ( $this->download_message_id === Installation::get_jilt_installed_from() ) {
+			$args = [ 'utm_term' => $this->download_message_id ];
+		}
+
+		return $args;
+	}
+
+
+	/**
 	 * Enqueues the assets.
 	 *
 	 * @internal

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -20,7 +20,9 @@ namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
 defined( 'ABSPATH' ) or exit;
 
 use Automattic\WooCommerce\Admin\PageController;
+use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Installation;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
+use SkyVerge\WooCommerce\Jilt_Promotions\Package;
 
 /**
  * The prompt handler for the Customers page.
@@ -35,6 +37,21 @@ final class Customers extends Prompt {
 
 	/** @var string the ID of the Customers page */
 	private $customers_page_id = 'woocommerce-analytics-customers';
+
+
+	/**
+	 * Enqueues the assets.
+	 *
+	 * @internal
+	 *
+	 * @since 1.1.0
+	 */
+	public function enqueue_assets() {
+
+		if ( $this->is_woocommerce_customers_page() ) {
+			wp_enqueue_script( 'sv-wc-jilt-prompt-customers', Package::get_assets_url() . '/js/admin/customers.min.js', [ Installation::INSTALL_SCRIPT_HANDLE ], Package::VERSION, true );
+		}
+	}
 
 
 	/**

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -55,6 +55,47 @@ final class Customers extends Prompt {
 
 
 	/**
+	 * Outputs the template for the I want to try Jilt modal.
+	 *
+	 * @internal
+	 *
+	 * @since 1.1.0
+	 */
+	public function render_try_jilt_modal() {
+
+		// bail if this is not the WooCommerce Customers page
+		if ( ! $this->is_woocommerce_customers_page() ) {
+			return;
+		}
+
+		?>
+		<script type="text/template" id="tmpl-sv-wc-jilt-promotions-<?php esc_attr_e( $this->download_message_id ); ?>-modal">
+			<div class="sv-wc-jilt-install-modal wc-backbone-modal">
+				<div class="wc-backbone-modal-content">
+					<section class="wc-backbone-modal-main" role="main">
+						<header class="wc-backbone-modal-header">
+							<h1><?php esc_html_e( 'Communicate with your customers in minutes!', 'sv-wc-jilt-promotions' ); ?></h1>
+							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
+								<span class="screen-reader-text"><?php esc_html_e( 'Close modal panel', 'sv-wc-jilt-promotions' ); ?></span>
+							</button>
+						</header>
+						<article><?php esc_html_e( 'Jilt automatically syncs your store and customer data, so you can send powerful, personalized messages to your customers with just a few clicks.', 'sv-wc-jilt-promotions' ); ?></article>
+						<footer>
+							<div class="inner">
+								<a href=""><?php esc_html_e( 'Learn more', 'sv-wc-jilt-promotions' ); ?></a>
+								<button id="sv-wc-jilt-install-button-install" class="button button-large button-primary"><?php esc_html_e( 'I want to try Jilt', 'sv-wc-jilt-promotions' ); ?></button>
+							</div>
+						</footer>
+					</section>
+				</div>
+			</div>
+			<div class="wc-backbone-modal-backdrop modal-close"></div>
+		</script>
+		<?php
+	}
+
+
+	/**
 	 * Determines whether the current page is the WooCommerce Customers admin page.
 	 *
 	 * @since 1.1.0

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -29,5 +29,8 @@ use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
 final class Customers extends Prompt {
 
 
-}
+	/** @var string the ID of the customers download message */
+	private $download_message_id = 'wc-customers-download';
 
+
+}

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Jilt for WooCommerce Promotions
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2020, SkyVerge, Inc. (info@skyverge.com)
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
+
+defined( 'ABSPATH' ) or exit;
+
+use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
+
+/**
+ * The prompt handler for the Customers page.
+ *
+ * @since 1.1.0
+ */
+final class Customers extends Prompt {
+
+
+}
+

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -36,9 +36,6 @@ final class Customers extends Prompt {
 	/** @var string the ID of the customers download message */
 	private $download_message_id = 'wc-customers-download';
 
-	/** @var string the ID of the Customers page */
-	private $customers_page_id = 'woocommerce-analytics-customers';
-
 
 	/**
 	 * Adds the necessary action & filter hooks.
@@ -86,7 +83,7 @@ final class Customers extends Prompt {
 	 */
 	public function enqueue_assets() {
 
-		if ( $this->is_woocommerce_customers_page() ) {
+		if ( $this->is_woocommerce_js_page() ) {
 			wp_enqueue_script( 'sv-wc-jilt-prompt-customers', Package::get_assets_url() . '/js/admin/customers.min.js', [ Installation::INSTALL_SCRIPT_HANDLE ], Package::VERSION, true );
 		}
 	}
@@ -101,8 +98,8 @@ final class Customers extends Prompt {
 	 */
 	public function render_try_jilt_modal() {
 
-		// bail if this is not the WooCommerce Customers page
-		if ( ! $this->is_woocommerce_customers_page() ) {
+		// bail if this is not a React-based WooCommerce page
+		if ( ! $this->is_woocommerce_js_page() ) {
 			return;
 		}
 
@@ -134,24 +131,24 @@ final class Customers extends Prompt {
 
 
 	/**
-	 * Determines whether the current page is the WooCommerce Customers admin page.
+	 * Determines whether the current page is a React-based WooCommerce page.
 	 *
 	 * @since 1.1.0
 	 *
 	 * @return bool
 	 */
-	private function is_woocommerce_customers_page() {
+	private function is_woocommerce_js_page() {
 
-		$is_customers_page = false;
+		$is_js_page = false;
 
 		if ( class_exists( PageController::class ) && is_callable( PageController::class, 'instance' ) && $page_controller = PageController::get_instance() ) {
 
 			if ( is_callable( [ $page_controller, 'get_current_page' ] ) && $current_page = $page_controller->get_current_page() ) {
-				$is_customers_page = isset( $current_page['id'] ) && $current_page['id'] === $this->customers_page_id;
+				$is_js_page = isset( $current_page['js_page'] ) && $current_page['js_page'];
 			}
 		}
 
-		return $is_customers_page;
+		return $is_js_page;
 	}
 
 

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -32,5 +32,8 @@ final class Customers extends Prompt {
 	/** @var string the ID of the customers download message */
 	private $download_message_id = 'wc-customers-download';
 
+	/** @var string the ID of the Customers page */
+	private $customers_page_id = 'woocommerce-analytics-customers';
+
 
 }

--- a/src/Admin/Customers.php
+++ b/src/Admin/Customers.php
@@ -19,6 +19,7 @@ namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
 
 defined( 'ABSPATH' ) or exit;
 
+use Automattic\WooCommerce\Admin\PageController;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
 
 /**
@@ -34,6 +35,28 @@ final class Customers extends Prompt {
 
 	/** @var string the ID of the Customers page */
 	private $customers_page_id = 'woocommerce-analytics-customers';
+
+
+	/**
+	 * Determines whether the current page is the WooCommerce Customers admin page.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool
+	 */
+	private function is_woocommerce_customers_page() {
+
+		$is_customers_page = false;
+
+		if ( class_exists( PageController::class ) && is_callable( PageController::class, 'instance' ) && $page_controller = PageController::get_instance() ) {
+
+			if ( is_callable( [ $page_controller, 'get_current_page' ] ) && $current_page = $page_controller->get_current_page() ) {
+				$is_customers_page = isset( $current_page['id'] ) && $current_page['id'] === $this->customers_page_id;
+			}
+		}
+
+		return $is_customers_page;
+	}
 
 
 }

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -24,7 +24,7 @@ use SkyVerge\WooCommerce\Jilt_Promotions\Admin\Emails;
 /**
  * The base prompt handler.
  *
- * @since 1.1.0-dev.1
+ * @since 1.1.0
  */
 abstract class Prompt {
 
@@ -45,7 +45,7 @@ abstract class Prompt {
 	/**
 	 * Constructor.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 */
 	public function __construct() {
 
@@ -56,7 +56,7 @@ abstract class Prompt {
 	/**
 	 * Adds the necessary action & filter hooks.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 */
 	private function add_hooks() {
 
@@ -74,7 +74,7 @@ abstract class Prompt {
 	 *
 	 * Subclasses can use this method to setup hooks only when the prompt should be displayed.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 */
 	abstract protected function add_prompt_hooks();
 
@@ -84,7 +84,7 @@ abstract class Prompt {
 	 *
 	 * @internal
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 *
 	 * @param array $args redirect args
 	 * @return array
@@ -113,7 +113,7 @@ abstract class Prompt {
 	 *
 	 * The returned array will be used only if it includes the utm_term arg.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 *
 	 * @return array
 	 */
@@ -123,7 +123,7 @@ abstract class Prompt {
 	/**
 	 * Whether the Jilt install prompt should be displayed.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 *
 	 * @return bool
 	 */
@@ -149,7 +149,7 @@ abstract class Prompt {
 	/**
 	 * Whether Jilt is already installed.
 	 *
-	 * @since 1.1.0-dev.1
+	 * @since 1.1.0
 	 *
 	 * @return bool
 	 */

--- a/src/Handlers/Prompt.php
+++ b/src/Handlers/Prompt.php
@@ -17,12 +17,12 @@
 
 namespace SkyVerge\WooCommerce\Jilt_Promotions\Handlers;
 
-use SkyVerge\WooCommerce\Jilt_Promotions\Admin\Emails;
-
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Jilt_Promotions\Admin\Emails;
+
 /**
- * The base prompts handler.
+ * The base prompt handler.
  *
  * @since 1.1.0-dev.1
  */

--- a/src/Package.php
+++ b/src/Package.php
@@ -76,6 +76,7 @@ class Package {
 		require_once( self::get_package_path() . '/Admin/Orders.php' );
 
 		new Messages();
+		new Handlers\Installation();
 		new Admin\Customers();
 		new Admin\Emails();
 	}

--- a/src/Package.php
+++ b/src/Package.php
@@ -71,10 +71,12 @@ class Package {
 		require_once( self::get_package_path() . '/Notices/Notice.php' );
 		require_once( self::get_package_path() . '/Handlers/Installation.php' );
 		require_once( self::get_package_path() . '/Handlers/Prompt.php' );
+		require_once( self::get_package_path() . '/Admin/Customers.php' );
 		require_once( self::get_package_path() . '/Admin/Emails.php' );
 		require_once( self::get_package_path() . '/Admin/Orders.php' );
 
 		new Messages();
+		new Admin\Customers();
 		new Admin\Emails();
 	}
 


### PR DESCRIPTION
# Summary

This PR adds the prompt handler for the modal shown in the WooCommerce Customer's page.

### Story: [CH 61037](https://app.clubhouse.io/skyverge/story/61037/create-customers-message-handler)
### Release: #3 

## Details

I found out that users can navigate between React-based WooCommerce page without reloading, so they can load WooCommerce > Dashboard and end up in the WooCommerce > Customers page without giving this prompt handler a chance to enqueue the assets and render the template modal.

As a result, I replaced the `is_woocommerce_customers_page()` method from the proposed implementation with a `is_woocommerce_js_page()`.

## QA

### Setup

1. Install Memberships
1. Update `composer.json` to use branch `dev-ch61037/create-customers-message-handler` of `skyverge/wc-jilt-promotions`.
1. `composer update skyverge/wc-jilt-promotions`

### Steps

1. Go to the WooCommerce > Customers page
    - [x] The source code includes a script tag with ID equal to `sv-wc-jilt-prompt-customers-js`
    - [x] The source code includes the `sv-wc-jilt-promotions-wc-customers-download-modal` modal template