### PR TITLE
Implement Admin\Orders methods

### DIFF
--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -19,6 +19,7 @@ namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
 
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Installation;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
+use SkyVerge\WooCommerce\Jilt_Promotions\Messages;
 
 defined( 'ABSPATH' ) or exit;
 
@@ -37,6 +38,8 @@ class Orders extends Prompt {
 	/**
 	 * Callback for the views_edit-shop_order filter.
 	 *
+	 * @internal
+	 *
 	 * @since 1.1.0-dev.1
 	 *
 	 * @param array $views
@@ -53,6 +56,12 @@ class Orders extends Prompt {
 	 */
 	protected function add_prompt_hooks() {
 
+		$is_message_dismissed = Messages::is_message_dismissed( $this->abandoned_carts_filter_message_id );
+		$orders_count         = $this->get_orders_count();
+
+		if( $orders_count > 10 && ! $is_message_dismissed ) {
+			add_filter( 'views_edit-shop_order', [ $this, 'add_abandoned_carts_view' ] );
+		}
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -170,6 +170,48 @@ class Orders extends Prompt {
 
 
 	/**
+	 * Returns the result of a queried sales report from WooCommerce.
+	 *
+	 * @since 1.1.0-dev.1
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/blob/9eae43c0d4dde8916608c45b7bf44b893bca1107/includes/admin/class-wc-admin-dashboard.php#L92-L102
+	 *
+	 * @return array
+	 */
+	private function get_woocommerce_report_data() {
+
+		$report_data = [
+			'number_of_orders' => 0,
+			'gross_sales'      => 0,
+		];
+
+		$woocommerce_plugin_path = WC()->plugin_path();
+
+		$admin_report_file = "/{$woocommerce_plugin_path}/includes/admin/reports/class-wc-admin-report.php";
+		$report_file       = "/{$woocommerce_plugin_path}/includes/admin/reports/class-wc-report-sales-by-date.php";
+
+		if ( is_readable( $admin_report_file ) && is_readable( $report_file ) ) {
+
+			include_once $admin_report_file;
+			include_once $report_file;
+
+			$sales_by_date                 = new \WC_Report_Sales_By_Date();
+			$sales_by_date->start_date     = strtotime( '-30 days' );
+			$sales_by_date->end_date       = strtotime( 'now' );
+			$sales_by_date->chart_groupby  = 'day';
+			$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
+
+			$report_data = $sales_by_date->get_report_data();
+
+			$report_data['number_of_orders'] = $report_data->total_orders;
+			$report_data['gross_sales']      = $report_data->total_sales;
+		}
+
+		return $report_data;
+	}
+
+
+	/**
 	 * Retrieves the abandoned carts count and the recovered revenue to render the recover carts modal.
 	 *
 	 * @since 1.1.0-dev.1

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -116,7 +116,9 @@ class Orders extends Prompt {
 	 */
 	private function get_orders_revenue() {
 
-		return 0.0;
+		$sales_data = $this->get_sales_data();
+
+		return $sales_data['gross_sales'];
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -162,10 +162,18 @@ class Orders extends Prompt {
 	 */
 	private function get_sales_data() {
 
-		return [
-			'number_of_orders' => 0,
-			'gross_sales'      => 0.0,
-		];
+		$transient_key = sprintf( '%s_sales_data', $this->abandoned_carts_filter_message_id );
+
+		$sales_data = get_transient( $transient_key );
+
+		if( ! isset( $sales_data ) ) {
+
+			$sales_data = $this->get_woocommerce_report_data();
+
+			set_transient( $transient_key, $sales_data, 24 * 60 * 60 );
+		}
+
+		return $sales_data;
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -70,7 +70,7 @@ class Orders extends Prompt {
 	 *
 	 * @since 1.1.0-dev.1
 	 *
-	 * @retun float
+	 * @retun int
 	 */
 	private function get_abandoned_carts_count() {
 
@@ -82,7 +82,7 @@ class Orders extends Prompt {
 		// 15% of carts are recovered
 		$carts_recovered_rate = 0.15;
 
-		return ( $orders_count / ( 1 - $carts_abandoned_rate ) ) * $carts_abandoned_rate * $carts_recovered_rate;
+		return ceil( ( $orders_count / ( 1 - $carts_abandoned_rate ) ) * $carts_abandoned_rate * $carts_recovered_rate );
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -133,7 +133,11 @@ class Orders extends Prompt {
 	 */
 	private function get_recovered_revenue() {
 
-		return 0.0;
+		$abandoned_carts_count = $this->get_abandoned_carts_count();
+		$orders_revenue        = $this->get_orders_revenue();
+		$orders_count          = $this->get_orders_count();
+
+		return ( $orders_revenue / $orders_count ) * $abandoned_carts_count;
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -17,6 +17,7 @@
 
 namespace SkyVerge\WooCommerce\Jilt_Promotions\Admin;
 
+use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Installation;
 use SkyVerge\WooCommerce\Jilt_Promotions\Handlers\Prompt;
 
 defined( 'ABSPATH' ) or exit;
@@ -69,13 +70,19 @@ class Orders extends Prompt {
 
 
 	/**
-	 * {@inheritDoc}
+	 * Gets the connection redirect args to attribute the plugin installation to this prompt.
 	 *
 	 * @since 1.1.0-dev.1
 	 */
 	protected function get_connection_redirect_args() {
 
-		return [];
+		$redirect_args = [];
+
+		if( Installation::get_jilt_installed_from() === $this->abandoned_carts_filter_message_id ) {
+			$redirect_args['utm_term'] = $this->abandoned_carts_filter_message_id;
+		}
+
+		return $redirect_args;
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -103,7 +103,9 @@ class Orders extends Prompt {
 	 */
 	private function get_orders_count() {
 
-		return 0;
+		$sales_data = $this->get_sales_data();
+
+		return $sales_data['number_of_orders'];
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -65,7 +65,15 @@ class Orders extends Prompt {
 	 */
 	private function get_abandoned_carts_count() {
 
-		return 0.0;
+		$orders_count = $this->get_orders_count();
+
+		// 70% of carts are abandoned
+		$carts_abandoned_rate = 0.7;
+
+		// 15% of carts are recovered
+		$carts_recovered_rate = 0.15;
+
+		return ( $orders_count / ( 1 - $carts_abandoned_rate ) ) * $carts_abandoned_rate * $carts_recovered_rate;
 	}
 
 

--- a/src/Admin/Orders.php
+++ b/src/Admin/Orders.php
@@ -46,6 +46,9 @@ class Orders extends Prompt {
 	 */
 	public function add_abandoned_carts_view( $views ) {
 
+		$views[ $this->abandoned_carts_filter_message_id ] = sprintf( '<a href="#">%s</a>', __( 'Abandoned Carts', 'sv-wc-jilt-promotions' ) );
+
+		return $views;
 	}
 
 


### PR DESCRIPTION
# Summary

This PR adds implementations to the `Orders` class.

### Story: [CH 61183](https://app.clubhouse.io/skyverge/story/61183/implement-admin-orders-methods)
### Release: #3 

## QA

- [x] Code review

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version